### PR TITLE
Add GUI test support to CI pipeline

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,7 +3,7 @@ name: Java CI with Gradle
 on:
   workflow_dispatch:
   push:
-    branches: [ "main", "p1/issue-15-ci-gui-test-failure" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Resolves #15 by adding Xvfb, a display server, to the Ubuntu runner and running `gradle build` through it. This should allow the pipeline to handle GUI tests instead of failing them completely as it was doing before.

This also adds the ability to manually trigger a workflow via the GitHub GUI. This can be found under the "Actions" tab.