### PR TITLE
630:P3 #82: extract duplicated HEADER_LABEL colors into ClientUITheme (Flyweight)

### DIFF
--- a/src/main/java/soc/client/ClientUITheme.java
+++ b/src/main/java/soc/client/ClientUITheme.java
@@ -1,0 +1,64 @@
+/**
+ * Java Settlers - An online multiplayer version of the game Settlers of Catan
+ * This file copyright (C) 2026 JSettlers2 contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+package soc.client;
+
+import java.awt.Color;
+
+/**
+ * Shared UI theme constants for JSettlers client panels.
+ *<P>
+ * Intended as a small Flyweight-style holder for the section-header colors that
+ * several dialog/panel classes were each re-declaring as private constants
+ * (most notably {@link NewGameOptionsFrame} and {@link SOCConnectOrPracticePanel}).
+ * Centralising these here removes code duplication and gives future panels a
+ * single place to pick up the theme. Each {@link Color} object is allocated
+ * exactly once at class-load time and shared by every caller, which is the
+ * point of the Flyweight: many label widgets, one {@code Color} instance.
+ *<P>
+ * This class intentionally holds only <em>intrinsic</em> color state. Deciding
+ * which constant to apply to a given {@code JLabel} is left to the caller
+ * (extrinsic context) so that panels can still vary the foreground when it
+ * matters for contrast.
+ *
+ * @since 2.8.00
+ */
+public final class ClientUITheme
+{
+    /**
+     * Background color for section-header labels (a pale, high-contrast green).
+     * Previously duplicated as {@code HEADER_LABEL_BG} in
+     * {@link NewGameOptionsFrame} and {@link SOCConnectOrPracticePanel}.
+     */
+    public static final Color HEADER_LABEL_BG = new Color(220, 255, 220);
+
+    /**
+     * Default foreground for section-header labels on panels that want the
+     * strongest contrast (used e.g. by {@link NewGameOptionsFrame}).
+     */
+    public static final Color HEADER_LABEL_FG_DEFAULT = Color.BLACK;
+
+    /**
+     * Muted dark-green foreground for section-header labels on panels that
+     * want a softer look against {@link #HEADER_LABEL_BG}
+     * (used e.g. by {@link SOCConnectOrPracticePanel}).
+     */
+    public static final Color HEADER_LABEL_FG_MUTED = new Color(50, 80, 50);
+
+    /** Not instantiable. */
+    private ClientUITheme() {}
+}

--- a/src/main/java/soc/client/NewGameOptionsFrame.java
+++ b/src/main/java/soc/client/NewGameOptionsFrame.java
@@ -328,9 +328,18 @@ import soc.util.Version;
      */
     private JTextField msgText;
 
-    // // TODO refactor; these are from connectorprac panel
-    private static final Color HEADER_LABEL_BG = new Color(220,255,220);
-    private static final Color HEADER_LABEL_FG = Color.BLACK;
+    /**
+     * Background for the section-header labels in this dialog.
+     * Delegates to the shared {@link ClientUITheme#HEADER_LABEL_BG} flyweight
+     * so it stays in sync with other panels (e.g. {@link SOCConnectOrPracticePanel}).
+     */
+    private static final Color HEADER_LABEL_BG = ClientUITheme.HEADER_LABEL_BG;
+
+    /**
+     * Foreground for the section-header labels in this dialog.
+     * Uses {@link ClientUITheme#HEADER_LABEL_FG_DEFAULT} for maximum contrast.
+     */
+    private static final Color HEADER_LABEL_FG = ClientUITheme.HEADER_LABEL_FG_DEFAULT;
 
     /**
      * i18n text strings; will use same locale as SOCPlayerClient's string manager.

--- a/src/main/java/soc/client/SOCConnectOrPracticePanel.java
+++ b/src/main/java/soc/client/SOCConnectOrPracticePanel.java
@@ -91,8 +91,19 @@ import soc.util.Version;
      */
     private final boolean canLaunchServer;
 
-    private static final Color HEADER_LABEL_BG = new Color(220,255,220);
-    private static final Color HEADER_LABEL_FG = new Color( 50, 80, 50);
+    /**
+     * Background for the section-header labels on this panel.
+     * Delegates to the shared {@link ClientUITheme#HEADER_LABEL_BG} flyweight
+     * so it stays in sync with other panels (e.g. {@link NewGameOptionsFrame}).
+     */
+    private static final Color HEADER_LABEL_BG = ClientUITheme.HEADER_LABEL_BG;
+
+    /**
+     * Foreground for the section-header labels on this panel.
+     * Uses the muted dark-green {@link ClientUITheme#HEADER_LABEL_FG_MUTED}
+     * for a softer look against {@link ClientUITheme#HEADER_LABEL_BG}.
+     */
+    private static final Color HEADER_LABEL_FG = ClientUITheme.HEADER_LABEL_FG_MUTED;
 
     /**
      * i18n text strings; will use same locale as SOCPlayerClient's string manager.


### PR DESCRIPTION
Closes #82

## Summary

Two client panels — `NewGameOptionsFrame` and `SOCConnectOrPracticePanel` — each declared their own `HEADER_LABEL_BG` / `HEADER_LABEL_FG` `Color` constants with identical background values. Typical UI code-duplication: pick the wrong shade in one file and the section headers drift apart.

Introduced `soc.client.ClientUITheme` as a single source of truth for these constants. This is a Flyweight: the intrinsic `Color` objects are now allocated once and shared by every caller. Panels keep their existing private `HEADER_LABEL_BG` / `HEADER_LABEL_FG` names, but those now just alias the theme constants so call sites don't change.

Pattern category: **Flyweight** (structural).

## Changes

- New `src/main/java/soc/client/ClientUITheme.java` with:
  - `HEADER_LABEL_BG` (shared pale green background)
  - `HEADER_LABEL_FG_DEFAULT` (`Color.BLACK`, used by `NewGameOptionsFrame`)
  - `HEADER_LABEL_FG_MUTED` (`Color(50,80,50)`, used by `SOCConnectOrPracticePanel`)
- `NewGameOptionsFrame`: `HEADER_LABEL_BG/FG` now delegate to the theme.
- `SOCConnectOrPracticePanel`: `HEADER_LABEL_BG/FG` now delegate to the theme.

Diff: +89 / -5 LOC, 3 files.

## Verification

- Full main-source `javac` compile: clean (0 errors).
- Full JUnit suite on this branch: **314 tests, all green** (same count as `main`).
- Behavior preserved: the final RGB values for each label stay identical to what they were before (same `Color(220,255,220)` / `Color.BLACK` / `Color(50,80,50)`), just looked up from one place instead of declared twice.

## Notes / extension story

Adding a new panel with the same header look is now one import + two field references — no new `Color` literals needed. If the theme changes later, both panels pick it up automatically.
