### PR TITLE
630:P3 #80: break soc.game -> soc.server layer violation via BoardServerExtension (Adapter)

### DIFF
--- a/src/main/java/soc/game/BoardServerExtension.java
+++ b/src/main/java/soc/game/BoardServerExtension.java
@@ -1,0 +1,76 @@
+/**
+ * Java Settlers - An online multiplayer version of the game Settlers of Catan
+ * This file copyright (C) 2026 JSettlers2 contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+package soc.game;
+
+/**
+ * Narrow server-side board capabilities that the {@code soc.game} package
+ * needs to reach for at runtime.
+ *<P>
+ * This interface exists purely to break a layer violation: {@link SOCGame}
+ * and {@link SOCGameDiceHandler} were importing {@code soc.server.SOCBoardAtServer}
+ * directly and down-casting to it, which is a circular dependency between the
+ * game model and the server implementation. Declaring the needed hooks here
+ * lets game-layer code depend on an abstraction that lives in its own package
+ * while the concrete implementation (the server's {@code SOCBoardAtServer})
+ * plugs in via <em>Adapter</em> at runtime.
+ *<P>
+ * Classic Adapter shape:
+ *<UL>
+ *  <LI> Target: {@code BoardServerExtension} (this interface, in {@code soc.game}).
+ *  <LI> Adaptee: the existing methods on {@code soc.server.SOCBoardAtServer}.
+ *  <LI> Adapter: {@code SOCBoardAtServer} itself, which now {@code implements}
+ *       this interface. Its method signatures already match, so no wrapper
+ *       class is needed -- it is its own class-level adapter.
+ *</UL>
+ *<P>
+ * Game-layer callers should check {@code board instanceof BoardServerExtension}
+ * instead of a concrete server class, and cast to this interface. That keeps
+ * the client build clean of any {@code soc.server.*} imports in the game
+ * package while leaving server behavior untouched.
+ *
+ * @since 2.8.00
+ */
+public interface BoardServerExtension
+{
+    /**
+     * Some scenarios mark a particular Land Area as "bonus-excluded". At the
+     * server this is stored on the server-side board subclass; game logic in
+     * {@link SOCGame#updateAtGameFirstTurn()} needs to read it to encode each
+     * player's second starting land area. Clients should never call this
+     * because the server translates the value into per-player state.
+     *
+     * @return the bonus-excluded Land Area number, or 0 if unused
+     * @see SOCPlayer#setStartingLandAreasEncoded(int)
+     */
+    int getBonusExcludeLandArea();
+
+    /**
+     * When a dice roll is being resolved at the server for a sea board running
+     * the Cloth Trade scenario ({@code _SC_CLVI}), villages may distribute
+     * cloth to players adjacent to them. {@link SOCGameDiceHandler} needs to
+     * invoke this at roll time; clients never do.
+     *
+     * @param game        the game being rolled in; callers pass {@code this} (or the outer game)
+     * @param rollRes     the in-progress {@link SOCGame.RollResult} so added cloth is recorded
+     * @param dice        the dice total just rolled
+     * @return true if distributing the cloth caused a player to reach the
+     *         scenario's cloth-count victory target (the caller should then
+     *         check for a winner); false otherwise
+     */
+    boolean distributeClothFromRoll(SOCGame game, SOCGame.RollResult rollRes, int dice);
+}

--- a/src/main/java/soc/game/SOCGame.java
+++ b/src/main/java/soc/game/SOCGame.java
@@ -28,7 +28,6 @@ import soc.disableDebug.D;
 import soc.game.GameAction.ActionType;
 import soc.game.GameAction.EffectType;
 import soc.message.SOCMessage;  // For static calls only; SOCGame does not interact with network messages
-import soc.server.SOCBoardAtServer;  // For calling server-only methods like distributeClothFromRoll
 import soc.util.DataUtils;
 import soc.util.IntPair;
 import soc.util.SOCFeatureSet;
@@ -4013,7 +4012,7 @@ public class SOCGame implements Serializable, Cloneable
      * and set the player's {@link SOCPlayerEvent#SVP_SETTLED_ANY_NEW_LANDAREA} flag.
      *<P>
      * Some scenarios use extra initial pieces in fixed locations, placed in
-     * {@link SOCBoardAtServer#startGame_putInitPieces(SOCGame)}.  To prevent the state or current player from
+     * {@link soc.server.SOCBoardAtServer#startGame_putInitPieces(SOCGame)}.  To prevent the state or current player from
      * advancing, temporarily set game state {@link #READY} before calling putPiece for these.
      *<P>
      * Adds {@link SOCShip}s to {@link #getShipsPlacedThisTurn()} except in gameState {@link #UNDOING_ACTION},
@@ -5860,7 +5859,8 @@ public class SOCGame implements Serializable, Cloneable
      *<UL>
      *<LI> Calls each player's {@link SOCPlayer#clearPotentialSettlements()}
      *
-     *<LI> At server, if {@link SOCBoardAtServer#getBonusExcludeLandArea()} != 0,
+     *<LI> At server, if the board implements {@link BoardServerExtension} and
+     *     {@link BoardServerExtension#getBonusExcludeLandArea()} != 0,
      *     use that to set each player's second starting land area as a client compatibility workaround
      *     for bonus calculations: Calls {@link SOCPlayer#setStartingLandAreasEncoded(int)}.
      *
@@ -5894,9 +5894,9 @@ public class SOCGame implements Serializable, Cloneable
         for (int pn = 0; pn < maxPlayers; ++pn)
             players[pn].clearPotentialSettlements();
 
-        if (board instanceof SOCBoardAtServer)
+        if (board instanceof BoardServerExtension)
         {
-            final int bxLAEnc = ((SOCBoardAtServer) board).getBonusExcludeLandArea() << 8;
+            final int bxLAEnc = ((BoardServerExtension) board).getBonusExcludeLandArea() << 8;
                 // Shift left for "encoded" form of players' 2nd starting land area.
                 // If bxLAEnc != 0, board must have 1 starting land area, so can assume players' 2nd starting LA is 0.
             if (bxLAEnc != 0)
@@ -6635,7 +6635,8 @@ public class SOCGame implements Serializable, Cloneable
      * and N7C: Roll no 7s until a city is built.
      *<P>
      * For scenario option {@link SOCGameOptionSet#K_SC_CLVI}, calls
-     * {@link SOCBoardAtServer#distributeClothFromRoll(SOCGame, RollResult, int)}.
+     * {@link BoardServerExtension#distributeClothFromRoll(SOCGame, RollResult, int)}
+     * (implemented by {@code soc.server.SOCBoardAtServer}).
      * Cloth are worth VP, so check for game state {@link #OVER} if results include {@link RollResult#cloth}.
      *<P>
      * For scenario option {@link SOCGameOptionSet#K_SC_PIRI}, calls {@link SOCBoardLarge#movePirateHexAlongPath(int)}
@@ -10526,7 +10527,7 @@ public class SOCGame implements Serializable, Cloneable
          *   [ Cloth amount taken from general supply,
          *     Cloth amount given to player 0, to player 1, ..., to player n ].
          * Any {@link SOCVillage}s with matching dice numbers which took part are in {@link #clothVillages}.
-         * @see SOCBoardAtServer#distributeClothFromRoll(SOCGame, RollResult, int)
+         * @see BoardServerExtension#distributeClothFromRoll(SOCGame, RollResult, int)
          */
         public int[] cloth;
 

--- a/src/main/java/soc/game/SOCGameDiceHandler.java
+++ b/src/main/java/soc/game/SOCGameDiceHandler.java
@@ -19,8 +19,6 @@
  **/
 package soc.game;
 
-import soc.server.SOCBoardAtServer;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -188,7 +186,9 @@ class SOCGameDiceHandler
             if (game.hasSeaBoard && game.isGameOptionSet(SOCGameOptionSet.K_SC_CLVI))
             {
                 // distribute will usually return false; most rolls don't hit dice#s which distribute cloth
-                if (((SOCBoardAtServer) game.getBoard()).distributeClothFromRoll(game, currentRoll, diceTotal))
+                final SOCBoard b = game.getBoard();
+                if ((b instanceof BoardServerExtension)
+                    && ((BoardServerExtension) b).distributeClothFromRoll(game, currentRoll, diceTotal))
                     game.checkForWinner();
             }
 

--- a/src/main/java/soc/server/SOCBoardAtServer.java
+++ b/src/main/java/soc/server/SOCBoardAtServer.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
 
+import soc.game.BoardServerExtension;
 import soc.game.SOCBoard;
 import soc.game.SOCBoard4p;
 import soc.game.SOCBoard6p;
@@ -149,6 +150,7 @@ import soc.util.IntTriple;
  * @since 2.0.00
  */
 public class SOCBoardAtServer extends SOCBoardLarge
+    implements BoardServerExtension
 {
     /**
      * Flag property {@code jsettlers.debug.board.fog}: When present, about 20% of the board's


### PR DESCRIPTION
Closes #80

## Summary

`soc.game.SOCGame` and `soc.game.SOCGameDiceHandler` both imported `soc.server.SOCBoardAtServer` and down-cast to it to call server-only methods. That's a circular layering violation: `soc.game` is the model layer and `soc.server` already depends on it, so `soc.game` should not be reaching back into `soc.server`.

Introduced `soc.game.BoardServerExtension` — a narrow interface declared in the game package that exposes exactly the two hooks the game logic needs:
- `getBonusExcludeLandArea()` (used in `SOCGame.updateAtGameFirstTurn()`)
- `distributeClothFromRoll(SOCGame, SOCGame.RollResult, int)` (used in `SOCGameDiceHandler`)

`SOCBoardAtServer` now `implements BoardServerExtension`. Its method signatures already matched, so it acts as its own class-level **Adapter**: no wrapper class, no behavior change, just a formally declared contract. Game-layer callers now cast to the interface (which lives in their own package) and the `import soc.server.SOCBoardAtServer;` is gone from both game-layer files.

Pattern category: **Adapter** (structural).

## Changes

- New `src/main/java/soc/game/BoardServerExtension.java` — the Target interface.
- `SOCBoardAtServer`: `implements BoardServerExtension` + corresponding import.
- `SOCGame`: removed `import soc.server.SOCBoardAtServer;`, cast to `BoardServerExtension` at the bonus-LA site, fixed four Javadoc `@link` / `@see` refs to either use the new interface or fully-qualified names.
- `SOCGameDiceHandler`: removed `import soc.server.SOCBoardAtServer;`, cast to `BoardServerExtension` at the cloth-distribution site, with an explicit `instanceof` guard for robustness.

Diff: +89 / -10 LOC, 4 files.

## Verification

- Full main-source `javac` compile: clean.
- Full JUnit suite: **314 tests, all green**.
- Behavior preserved: identical method dispatch at runtime; only the compile-time type seen by game-layer code changed.
- Confirmed the game package no longer has a single `import soc.server.*` (`git grep 'import soc\.server' src/main/java/soc/game/` returns nothing).

## Notes / extension story

Adding a new server-only hook the game layer needs to consult now starts with a single new method on `BoardServerExtension` and an implementation on `SOCBoardAtServer`; no new cross-package imports needed in the game package.
