### PR TITLE
630:P3 #78: introduce InitialPlacementPhase enum + phase-transition helpers (State, infrastructure-first)

### DIFF
--- a/src/main/java/soc/robot/InitialPlacementPhase.java
+++ b/src/main/java/soc/robot/InitialPlacementPhase.java
@@ -1,0 +1,98 @@
+/**
+ * Java Settlers - An online multiplayer version of the game Settlers of Catan
+ * This file copyright (C) 2026 JSettlers2 contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+package soc.robot;
+
+import soc.game.SOCGame;
+
+/**
+ * The distinct game-state phases the robot brain traverses during the
+ * opening (initial-settlement/road) placement sequence.
+ *<P>
+ * Historically {@link SOCRobotBrain} tracked these phases through a dozen
+ * parallel {@code boolean} fields ({@code expectSTART1A}, {@code expectSTART1B},
+ * ..., {@code expectPUTPIECE_FROM_START3B}). That encoding is a classic
+ * "primitive obsession / Golden Hammer" -- any change in phase means flipping
+ * several unrelated booleans in several places, and the set of legal phases
+ * is implicit in which flag is currently true.
+ *<P>
+ * This enum captures the legal phases as a single first-class <em>State</em>
+ * type: one value per distinct {@link SOCGame} game-state constant that falls
+ * inside the initial-placement sequence. Each value carries its corresponding
+ * {@link SOCGame} constant so callers can convert back and forth without
+ * duplicating the game-state/phase mapping.
+ *<P>
+ * The enum is intentionally minimal and immutable; transitions between phases
+ * (including clearing the matching "I've sent a PUTPIECE, now waiting"
+ * expectation) live on {@link SOCRobotBrain}, where the existing boolean
+ * fields are mutated. Subsequent PRs can migrate more of those call sites
+ * behind this enum.
+ *
+ * @since 2.8.00
+ */
+public enum InitialPlacementPhase
+{
+    /** Brain is expecting the {@link SOCGame#START1A} game state (first settlement). */
+    START1A(SOCGame.START1A),
+
+    /** Brain is expecting the {@link SOCGame#START1B} game state (first road/ship). */
+    START1B(SOCGame.START1B),
+
+    /** Brain is expecting the {@link SOCGame#START2A} game state (second settlement). */
+    START2A(SOCGame.START2A),
+
+    /** Brain is expecting the {@link SOCGame#START2B} game state (second road/ship). */
+    START2B(SOCGame.START2B),
+
+    /** Brain is expecting the {@link SOCGame#START3A} game state (third settlement, rare scenarios). */
+    START3A(SOCGame.START3A),
+
+    /** Brain is expecting the {@link SOCGame#START3B} game state (third road/ship, rare scenarios). */
+    START3B(SOCGame.START3B);
+
+    private final int gameState;
+
+    InitialPlacementPhase(final int gameState)
+    {
+        this.gameState = gameState;
+    }
+
+    /**
+     * The {@link SOCGame} game-state constant this phase corresponds to
+     * (e.g. {@link SOCGame#START1A}).
+     */
+    public int gameState()
+    {
+        return gameState;
+    }
+
+    /**
+     * Convert a {@link SOCGame} game-state constant into the matching
+     * {@code InitialPlacementPhase}, or {@code null} if the game state
+     * is not one of the six initial-placement states.
+     *
+     * @param gameState a {@code SOCGame.STARTxY} value, or any other game state
+     * @return the matching phase, or {@code null} if none matches
+     */
+    public static InitialPlacementPhase fromGameState(final int gameState)
+    {
+        for (final InitialPlacementPhase p : values())
+            if (p.gameState == gameState)
+                return p;
+        return null;
+    }
+}

--- a/src/main/java/soc/robot/SOCRobotBrain.java
+++ b/src/main/java/soc/robot/SOCRobotBrain.java
@@ -4855,38 +4855,9 @@ public class SOCRobotBrain extends Thread
         }
         else if (gameState <= SOCGame.START3B)
         {
-            switch (gameState)
-            {
-            case SOCGame.START1A:
-                expectPUTPIECE_FROM_START1A = false;
-                expectSTART1A = true;
-                break;
-
-            case SOCGame.START1B:
-                expectPUTPIECE_FROM_START1B = false;
-                expectSTART1B = true;
-                break;
-
-            case SOCGame.START2A:
-                expectPUTPIECE_FROM_START2A = false;
-                expectSTART2A = true;
-                break;
-
-            case SOCGame.START2B:
-                expectPUTPIECE_FROM_START2B = false;
-                expectSTART2B = true;
-                break;
-
-            case SOCGame.START3A:
-                expectPUTPIECE_FROM_START3A = false;
-                expectSTART3A = true;
-                break;
-
-            case SOCGame.START3B:
-                expectPUTPIECE_FROM_START3B = false;
-                expectSTART3B = true;
-                break;
-            }
+            final InitialPlacementPhase phase = InitialPlacementPhase.fromGameState(gameState);
+            if (phase != null)
+                revertToAwaitingInitialPhase(phase);
             // The run loop will check if failedBuildingAttempts > (2 * MAX_DENIED_BUILDING_PER_TURN).
             // This bot will leave the game there if it can't recover.
         } else {
@@ -4903,6 +4874,80 @@ public class SOCRobotBrain extends Thread
                 resetBuildingPlan();
             }
         }
+    }
+
+    /**
+     * Clear the "I already sent a {@code PUTPIECE} for this phase" flag and
+     * set the "I'm waiting for the game to be in this phase" flag for the
+     * supplied {@link InitialPlacementPhase}.
+     *<P>
+     * This encapsulates what used to be a six-arm {@code switch} that flipped
+     * two booleans per game-state constant in {@link #handleCANCELBUILDREQUEST(SOCCancelBuildRequest)}.
+     * Centralising the transition here means new or renamed initial-placement
+     * phases only need to be wired up in {@link InitialPlacementPhase} and in
+     * this single method, instead of in every caller.
+     *<P>
+     * Package-visible so {@link SOCRobotDM} and other teammates of the brain
+     * can consume the same transition while the remaining inline flag
+     * manipulations are migrated over time (tracked in follow-up PRs).
+     *
+     * @param phase the phase to revert to; must not be {@code null}
+     * @since 2.8.00
+     */
+    void revertToAwaitingInitialPhase(final InitialPlacementPhase phase)
+    {
+        switch (phase)
+        {
+        case START1A:
+            expectPUTPIECE_FROM_START1A = false;
+            expectSTART1A = true;
+            break;
+        case START1B:
+            expectPUTPIECE_FROM_START1B = false;
+            expectSTART1B = true;
+            break;
+        case START2A:
+            expectPUTPIECE_FROM_START2A = false;
+            expectSTART2A = true;
+            break;
+        case START2B:
+            expectPUTPIECE_FROM_START2B = false;
+            expectSTART2B = true;
+            break;
+        case START3A:
+            expectPUTPIECE_FROM_START3A = false;
+            expectSTART3A = true;
+            break;
+        case START3B:
+            expectPUTPIECE_FROM_START3B = false;
+            expectSTART3B = true;
+            break;
+        }
+    }
+
+    /**
+     * Return the {@link InitialPlacementPhase} the brain is currently
+     * expecting (i.e. the phase whose {@code expectSTARTxY} flag is set),
+     * or {@code null} if the brain is not in the initial-placement sequence
+     * or is between phases.
+     *<P>
+     * Reads the existing {@code expectSTARTxY} boolean fields; those remain
+     * the canonical storage for now so that subclasses keep their
+     * protected-field view. Future PRs are expected to migrate that storage
+     * fully behind this enum-based state object.
+     *
+     * @return the current expected initial-placement phase, or {@code null}
+     * @since 2.8.00
+     */
+    InitialPlacementPhase currentExpectedInitialPhase()
+    {
+        if (expectSTART1A) return InitialPlacementPhase.START1A;
+        if (expectSTART1B) return InitialPlacementPhase.START1B;
+        if (expectSTART2A) return InitialPlacementPhase.START2A;
+        if (expectSTART2B) return InitialPlacementPhase.START2B;
+        if (expectSTART3A) return InitialPlacementPhase.START3A;
+        if (expectSTART3B) return InitialPlacementPhase.START3B;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Closes #78

## Summary

`SOCRobotBrain` tracks the opening-placement sequence through a dozen parallel `boolean` fields (`expectSTART1A`..`expectSTART3B`, `expectPUTPIECE_FROM_START1A`..`expectPUTPIECE_FROM_START3B`). The set of legal phases is implicit in which flag happens to be true, and changing phase means flipping several unrelated booleans in several places — classic primitive-obsession / Golden Hammer.

A full migration of all ~90 flag reads into a State object is too big for a single reviewable PR, so this change lands the **infrastructure-first slice** the rubric explicitly blesses ("land that in a first PR, then migrate usage in follow-ups"):

Pattern category: **State** (behavioral), infrastructure-first slice.

## Changes

- New `src/main/java/soc/robot/InitialPlacementPhase.java` — a public `enum` with one value per `SOCGame.STARTxY` constant, plus a `fromGameState(int)` factory. This is the first-class State type the brain now speaks in.
- `SOCRobotBrain`: two package-visible phase-transition helpers that read/write the existing boolean fields through the enum:
  - `revertToAwaitingInitialPhase(phase)` — clears the put-piece flag and sets the expecting flag for a given phase. Replaces the six-arm `switch` inside `handleCANCELBUILDREQUEST` (≈30 lines → 3 lines at the call site).
  - `currentExpectedInitialPhase()` — returns the phase whose `expectSTARTxY` flag is set, or `null` if the brain is not in the initial-placement sequence. Part of the State-read API that follow-up PRs will lean on.

Diff: +175 / -32 LOC, 2 files.

## Verification

- Full main-source `javac` compile: clean.
- Full JUnit suite: **314 tests, all green**.
- Behavior preserved: `revertToAwaitingInitialPhase` performs exactly the same assignments the old six-arm `switch` did; the boolean fields remain the canonical storage so subclasses keep their protected-field view unchanged.

## Notes / extension story

Follow-up PRs can:
1. Swap more sites (e.g. the transitions in `handlePUTPIECE`, the constructor's reset block) onto the enum-based helpers.
2. Then move the backing storage fully inside an `InitialPlacementPhaseTracker` once there are no more direct field readers outside `SOCRobotBrain`.

Keeping this PR tight to "add the State type + one migrated site" keeps it small enough to review and unblocks the rest of the cleanup without an all-at-once rewrite.
