### PR TITLE
630:P3 Flag Argument in extractContentsHalf() → refactor to Strategy (src vs dest behavior)

### DIFF
--- a/src/main/java/net/nand/util/i18n/ParsedPropsFilePair.java
+++ b/src/main/java/net/nand/util/i18n/ParsedPropsFilePair.java
@@ -31,38 +31,47 @@ import java.util.Map;
 import net.nand.util.i18n.PropsFileParser.KeyPairLine;
 
 /**
- * Represents a source-language and destination-language pair of properties files.
- * There should be no keys in the target that aren't in the source.
- * Each key in the source/destination is a {@link ParsedPropsFilePair.FileEntry} here.
- *<P>
- * Remember that {@code .properties} bundle files are encoded not in {@code UTF-8} but in {@code ISO-8859-1}:
- *<UL>
- * <LI> <A href="https://docs.oracle.com/javase/6/docs/api/java/util/Properties.html"
- *       >java.util.Properties</A> (Java 6)
- * <LI> <A href="http://stackoverflow.com/questions/4659929/how-to-use-utf-8-in-resource-properties-with-resourcebundle"
- *       >Stack Overflow: How to use UTF-8 in resource properties with ResourceBundle</A> (asked on 2011-01-11)
- *</UL>
- * Characters outside that encoding must use <code>&#92;uXXXX</code> code escapes.
- *<P>
- * The parsed merged list is {@link #getContents()}, any keys only in the destination are in {@link #getDestOnly()}.
- * The source or destination "half" can be generated with {@link #extractContentsHalf(boolean)}.
- * Changes to that "half" can then be saved with {@link PropsFileWriter}.
+ * Represents a source-language and destination-language pair of properties
+ * files. There should be no keys in the target that aren't in the source. Each
+ * key in the source/destination is a {@link ParsedPropsFilePair.FileEntry}
+ * here.
+ * <P>
+ * Remember that {@code .properties} bundle files are encoded not in
+ * {@code UTF-8} but in {@code ISO-8859-1}:
+ * <UL>
+ * <LI>
+ * <A href="https://docs.oracle.com/javase/6/docs/api/java/util/Properties.html"
+ * >java.util.Properties</A> (Java 6)
+ * <LI><A href=
+ * "http://stackoverflow.com/questions/4659929/how-to-use-utf-8-in-resource-properties-with-resourcebundle"
+ * >Stack Overflow: How to use UTF-8 in resource properties with
+ * ResourceBundle</A> (asked on 2011-01-11)
+ * </UL>
+ * Characters outside that encoding must use <code>&#92;uXXXX</code> code
+ * escapes.
+ * <P>
+ * The parsed merged list is {@link #getContents()}, any keys only in the
+ * destination are in {@link #getDestOnly()}. The source or destination "half"
+ * can be generated with {@link #extractContentsHalf(boolean)}. Changes to that
+ * "half" can then be saved with {@link PropsFileWriter}.
  *
  * @author Jeremy D Monin &lt;jeremy@nand.net&gt;
  */
 public class ParsedPropsFilePair
 {
-    /** If true, there are unsaved changes from editing the pair.
-     *  If new rows were inserted, {@link #unsavedInsRows} will also be set.
+    /**
+     * If true, there are unsaved changes from editing the pair. If new rows were
+     * inserted, {@link #unsavedInsRows} will also be set.
      */
     public boolean unsavedSrc, unsavedDest;
 
-    /** If true, there are unsaved inserted rows.
-     *  You can call {@link #convertInsertedRows()} to make them key or comment rows.
-     *  To avoid inconsistencies when saving changes, {@link #extractContentsHalf(boolean)}
-     *  will call that method if {@code unsavedInsRows}.
-     *  If you call {@link #convertInsertedRows()} yourself first, you can check its return value
-     *  to see if any conversions were needed.
+    /**
+     * If true, there are unsaved inserted rows. You can call
+     * {@link #convertInsertedRows()} to make them key or comment rows. To avoid
+     * inconsistencies when saving changes, {@link #extractContentsHalf(boolean)}
+     * will call that method if {@code unsavedInsRows}. If you call
+     * {@link #convertInsertedRows()} yourself first, you can check its return value
+     * to see if any conversions were needed.
      */
     public boolean unsavedInsRows;
 
@@ -71,56 +80,70 @@ public class ParsedPropsFilePair
     /** If true, {@link #setDestIsNew(List)} has been called. */
     private boolean isDestNew;
 
-    /** Logical entries, one per key, to be expanded into {@link #cont}:
-     *  Source and dest file-pair key-by-key contents, from parsing; does not contain {@link #destOnlyPairs}.
-     *  Built during {@link #parseSrc()}, updated during {@link #parseDest()}.
-     *  @see #srcParsedDupeKeys
-     *  @see #destParsedDupeKeys
+    /**
+     * Logical entries, one per key, to be expanded into {@link #cont}: Source and
+     * dest file-pair key-by-key contents, from parsing; does not contain
+     * {@link #destOnlyPairs}. Built during {@link #parseSrc()}, updated during
+     * {@link #parseDest()}.
+     * 
+     * @see #srcParsedDupeKeys
+     * @see #destParsedDupeKeys
      */
     private List<FileKeyEntry> parsed;
 
     /**
-     * Any duplicate keys found during parsing, or {@code null} if none.
-     * Key = each key seen more than once while parsing, value = values for that key.
-     * Built during {@link #parseSrc()} or {@link #parseDest()}.
-     *<P>
-     * For structure details see {@link PropsFileParser#findDuplicateKeys(List, Map)},
-     * including special case of 'duplicates' with same value.
+     * Any duplicate keys found during parsing, or {@code null} if none. Key = each
+     * key seen more than once while parsing, value = values for that key. Built
+     * during {@link #parseSrc()} or {@link #parseDest()}.
+     * <P>
+     * For structure details see
+     * {@link PropsFileParser#findDuplicateKeys(List, Map)}, including special case
+     * of 'duplicates' with same value.
+     * 
      * @see #parsed
      * @see #cont
      */
     private Map<String, String> srcParsedDupeKeys, destParsedDupeKeys;
 
-    /** Expanded entries (contents), one per line in file, from {@link #parsed}:
-     *  Source and dest file-pair line-by-line grid contents, from parsing and editing;
-     *  also contains {@link #destOnlyPairs}.  Built during {@link #parseDest()} or {@link #setDestIsNew(List)}
-     *  by {@link #buildContFromSrcDest(Map)}.
-     *  @see #srcParsedDupeKeys
-     *  @see #destParsedDupeKeys
+    /**
+     * Expanded entries (contents), one per line in file, from {@link #parsed}:
+     * Source and dest file-pair line-by-line grid contents, from parsing and
+     * editing; also contains {@link #destOnlyPairs}. Built during
+     * {@link #parseDest()} or {@link #setDestIsNew(List)} by
+     * {@link #buildContFromSrcDest(Map)}.
+     * 
+     * @see #srcParsedDupeKeys
+     * @see #destParsedDupeKeys
      */
     private List<FileEntry> cont;
 
-    /** If the file starts with a comment followed by blank lines above the first a key-value pair, comment goes in {@link #cont} and also goes here */
+    /**
+     * If the file starts with a comment followed by blank lines above the first a
+     * key-value pair, comment goes in {@link #cont} and also goes here
+     */
     private FileKeyEntry contHeadingComment;
 
-    /** If the file ends with a comment not followed by a key-value pair, it goes in {@link #cont} and also goes here */
+    /**
+     * If the file ends with a comment not followed by a key-value pair, it goes in
+     * {@link #cont} and also goes here
+     */
     private FileKeyEntry contEndingComment;
 
     /**
-     * Key-value pairs found only in the destination file, not the source file; or {@code null} if none.
-     * Initialized in {@link #parseDest()} if needed.
+     * Key-value pairs found only in the destination file, not the source file; or
+     * {@code null} if none. Initialized in {@link #parseDest()} if needed.
      */
     private List<PropsFileParser.KeyPairLine> destOnlyPairs;
 
     /**
      * Create a new empty FilePair to begin parsing.
-     *<P>
-     * If {@code src} and {@code dest} already exist on disk,
-     * call {@link #parseSrc()} and then {@link #parseDest()}
-     * to read them into this object.
+     * <P>
+     * If {@code src} and {@code dest} already exist on disk, call
+     * {@link #parseSrc()} and then {@link #parseDest()} to read them into this
+     * object.
      *
      * @param src  Source language/locale's properties file
-     * @param dest  Destination language/locale's properties file
+     * @param dest Destination language/locale's properties file
      */
     public ParsedPropsFilePair(final File src, final File dest)
     {
@@ -131,75 +154,147 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Get the number of key-value pairs in {@link #getContents()}.
-     * Each row can be retrieved with {@link #getRow(int)}.
+     * Get the number of key-value pairs in {@link #getContents()}. Each row can be
+     * retrieved with {@link #getRow(int)}.
      */
-    public int size() { return cont.size(); }
+    public int size()
+    {
+        return cont.size();
+    }
 
     /**
-     * Get the list of key-value pairs found in the source and maybe also the destination.
-     * The size of this list is {@link #size()}.
-     * For access to individual rows, use {@link #getRow(int)}.
+     * Get the list of key-value pairs found in the source and maybe also the
+     * destination. The size of this list is {@link #size()}. For access to
+     * individual rows, use {@link #getRow(int)}.
+     * 
      * @see #extractContentsHalf(boolean)
      * @see #getSrcDupeKeys()
      * @see #getDestDupeKeys()
      */
-    public Iterator<FileEntry> getContents() { return cont.iterator(); }
+    public Iterator<FileEntry> getContents()
+    {
+        return cont.iterator();
+    }
 
     /**
-     * Get the source or destination "half" of the parsed pair's contents,
-     * in a format suitable for {@link PropsFileWriter#write(List, String)}.
-     *<P>
+     * Strategy interface for extracting one "half" (source or destination) of a
+     * paired properties file entry.
+     *
+     * Encapsulates how to retrieve comment text, value, and formatting from a
+     * FileEntry without using conditional logic.
+     */
+    private interface ContentsHalfExtractor
+    {
+        String getComment(FileCommentEntry kp);
+
+        CharSequence getValue(FileKeyEntry kp);
+
+        boolean isSpacedEquals(FileKeyEntry kp);
+    }
+
+    /**
+     * Strategy for extracting the source (base) half of each entry. Uses
+     * srcComment, srcValue, and srcSpacedEquals fields.
+     */
+    private static final ContentsHalfExtractor SRC_HALF = new ContentsHalfExtractor()
+    {
+        public String getComment(final FileCommentEntry kp)
+        {
+            return kp.srcComment;
+        }
+
+        public CharSequence getValue(final FileKeyEntry kp)
+        {
+            return kp.srcValue;
+        }
+
+        public boolean isSpacedEquals(final FileKeyEntry kp)
+        {
+            return kp.srcSpacedEquals;
+        }
+    };
+
+    /**
+     * Strategy for extracting the destination (translated) half of each entry. Uses
+     * destComment, destValue, and destSpacedEquals fields.
+     */
+    private static final ContentsHalfExtractor DEST_HALF = new ContentsHalfExtractor()
+    {
+        public String getComment(final FileCommentEntry kp)
+        {
+            return kp.destComment;
+        }
+
+        public CharSequence getValue(final FileKeyEntry kp)
+        {
+            return kp.destValue;
+        }
+
+        public boolean isSpacedEquals(final FileKeyEntry kp)
+        {
+            return kp.destSpacedEquals;
+        }
+    };
+
+    /**
+     * Get the source or destination "half" of the parsed pair's contents, in a
+     * format suitable for {@link PropsFileWriter#write(List, String)}.
+     * <P>
      * To avoid inconsistencies when saving changes, checks {@link #unsavedInsRows}
      * and will call {@link #convertInsertedRows()} if needed.
-     *<P>
+     * <P>
      * Lines with a key but no value are ignored and not extracted.
      *
-     * @param destHalf  True for destination half, false for source half
-     * @return  List of key pair lines; may contain comment lines (null keys).
+     * @param destHalf True for destination half, false for source half
+     * @return List of key pair lines; may contain comment lines (null keys).
      * @see #getContents()
      */
     public List<KeyPairLine> extractContentsHalf(final boolean destHalf)
+    {
+        return extractContentsHalf(destHalf ? DEST_HALF : SRC_HALF);
+    }
+
+    /**
+     * Extract contents using the provided extraction strategy.
+     *
+     * Iterates through all file entries and delegates the extraction logic (source
+     * vs destination) to the given strategy, eliminating conditional branching
+     * inside the loop.
+     *
+     * @param extractor Strategy defining how to extract each entry
+     * @return List of extracted KeyPairLine objects
+     */
+    private List<KeyPairLine> extractContentsHalf(final ContentsHalfExtractor extractor)
     {
         if (unsavedInsRows)
             convertInsertedRows();
 
         ArrayList<KeyPairLine> ret = new ArrayList<KeyPairLine>(cont.size());
-        for (final FileEntry kp: cont)
+
+        for (final FileEntry kp : cont)
         {
             if (kp instanceof FileCommentEntry)
             {
-                String commentLine;
-                if (destHalf)
-                    commentLine = ((FileCommentEntry) kp).destComment;
-                else
-                    commentLine = ((FileCommentEntry) kp).srcComment;
+                final String commentLine = extractor.getComment((FileCommentEntry) kp);
 
                 if (commentLine == null)
                     ret.add(new KeyPairLine(null));
-                else {
+                else
+                {
                     ArrayList<String> oneline = new ArrayList<String>(2);
                     oneline.add(commentLine);
                     ret.add(new KeyPairLine(oneline));
                 }
-            } else {
-                FileKeyEntry kpe = (FileKeyEntry) kp;
-                final CharSequence val;
-                final boolean spc;
-                if (destHalf)
-                {
-                    val = kpe.destValue;
-                    spc = kpe.destSpacedEquals;
-                } else {
-                    val = kpe.srcValue;
-                    spc = kpe.srcSpacedEquals;
-                }
+            }
+            else
+            {
+                final FileKeyEntry kpe = (FileKeyEntry) kp;
+                final CharSequence val = extractor.getValue(kpe);
 
                 if (val == null)
-                    continue;  // skip it: only the other half of the dest/src pair has a value for this key
+                    continue;
 
-                ret.add(new KeyPairLine
-                        (kpe.key, val.toString(), null, spc));
+                ret.add(new KeyPairLine(kpe.key, val.toString(), null, extractor.isSpacedEquals(kpe)));
             }
         }
 
@@ -207,15 +302,17 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Get row {@code r} of the contents.
-     * This is a reference, not a copy; if you change its fields,
-     * be sure to set the {@link #unsavedDest} and/or {@link #unsavedSrc} flags.
-     * @param r  A row number within the contents, 0 &lt;= {@code r} &lt; {@link #size()}
-     * @return  The FileEntry in row {@code r}
+     * Get row {@code r} of the contents. This is a reference, not a copy; if you
+     * change its fields, be sure to set the {@link #unsavedDest} and/or
+     * {@link #unsavedSrc} flags.
+     * 
+     * @param r A row number within the contents, 0 &lt;= {@code r} &lt;
+     *          {@link #size()}
+     * @return The FileEntry in row {@code r}
      * @throws ArrayIndexOutOfBoundsException
      */
     public FileEntry getRow(final int r)
-        throws ArrayIndexOutOfBoundsException
+            throws ArrayIndexOutOfBoundsException
     {
         if ((r < 0) || (r >= cont.size()))
             throw new ArrayIndexOutOfBoundsException(r);
@@ -223,8 +320,8 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Is this key found only in the destination file, not in the source file?
-     * This is an error and a rare occurrence.
+     * Is this key found only in the destination file, not in the source file? This
+     * is an error and a rare occurrence.
      */
     public boolean isKeyDestOnly(final String key)
     {
@@ -240,7 +337,9 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Get the number of key-value pairs found only in the destination, or 0,  in {@link #getDestOnly()}.
+     * Get the number of key-value pairs found only in the destination, or 0, in
+     * {@link #getDestOnly()}.
+     * 
      * @see #isKeyDestOnly(String)
      */
     public int getDestOnlySize()
@@ -249,8 +348,9 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Get the list of key-value pairs found only in the destination, or {@code null} if none.
-     * The size of this list is {@link #getDestOnlySize()}.
+     * Get the list of key-value pairs found only in the destination, or
+     * {@code null} if none. The size of this list is {@link #getDestOnlySize()}.
+     * 
      * @see #getContents()
      * @see #getDestDupeKeys()
      */
@@ -262,7 +362,8 @@ public class ParsedPropsFilePair
     /**
      * Get any keys seen during source parsing more than once with different values.
      * Same map format as {@link PropsFileParser#findDuplicateKeys(List, Map)}.
-     * @return  Duplicate keys in source file, or {@code null} if none
+     * 
+     * @return Duplicate keys in source file, or {@code null} if none
      * @see #getDestDupeKeys()
      * @see #getContents()
      * @see #getDestOnly()
@@ -273,9 +374,11 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Get any keys seen during destination parsing more than once with different values.
-     * Same map format as {@link PropsFileParser#findDuplicateKeys(List, Map)}.
-     * @return  Duplicate keys in destination file, or {@code null} if none
+     * Get any keys seen during destination parsing more than once with different
+     * values. Same map format as
+     * {@link PropsFileParser#findDuplicateKeys(List, Map)}.
+     * 
+     * @return Duplicate keys in destination file, or {@code null} if none
      * @see #getSrcDupeKeys()
      * @see #getContents()
      */
@@ -285,22 +388,24 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Parse the source-language file at {@link #srcFile}.
-     * After calling this method, call {@link #parseDest()} or {@link #setDestIsNew(List)}.
-     * @throws IllegalStateException  if we've already read or created entries in this object; {@link #size()} != 0
-     * @throws IOException  if file not found, cannot be read, etc
+     * Parse the source-language file at {@link #srcFile}. After calling this
+     * method, call {@link #parseDest()} or {@link #setDestIsNew(List)}.
+     * 
+     * @throws IllegalStateException if we've already read or created entries in
+     *                               this object; {@link #size()} != 0
+     * @throws IOException           if file not found, cannot be read, etc
      */
     public void parseSrc()
-        throws IllegalStateException, IOException
+            throws IllegalStateException, IOException
     {
-        if (! parsed.isEmpty())
+        if (!parsed.isEmpty())
             throw new IllegalStateException("cannot call parseSrc unless object is empty");
 
         Map<String, String> dupeKeys = new HashMap<String, String>();
         final List<PropsFileParser.KeyPairLine> srcLines = PropsFileParser.parseOneFile(srcFile, dupeKeys);
         if (srcLines.isEmpty())
             return;
-        if (! dupeKeys.isEmpty())
+        if (!dupeKeys.isEmpty())
             srcParsedDupeKeys = dupeKeys;
 
         final PropsFileParser.KeyPairLine firstLine = srcLines.get(0);
@@ -309,7 +414,7 @@ public class ParsedPropsFilePair
             FileKeyEntry fe = new FileKeyEntry(firstLine.comment);
             parsed.add(fe);
             contHeadingComment = fe;
-            srcLines.remove(0);   // main loop expects line.key except for very last entry
+            srcLines.remove(0); // main loop expects line.key except for very last entry
         }
 
         for (final PropsFileParser.KeyPairLine line : srcLines)
@@ -321,7 +426,9 @@ public class ParsedPropsFilePair
                     fe.srcComment = line.comment;
                 fe.srcSpacedEquals = line.spacedEquals;
                 parsed.add(fe);
-            } else if (line.comment != null) {
+            }
+            else if (line.comment != null)
+            {
                 FileKeyEntry fe = new FileKeyEntry(line.comment);
                 parsed.add(fe);
                 if (contEndingComment != null)
@@ -332,18 +439,20 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Call this method to indicate that {@link #destFile} is new and does not yet exist.
-     * Optionally provide header comments to place in the destination.
-     *<P>
-     * Call {@link #parseSrc()} before calling this method.
-     * If you call this method, do not call {@link #parseDest()}.
+     * Call this method to indicate that {@link #destFile} is new and does not yet
+     * exist. Optionally provide header comments to place in the destination.
+     * <P>
+     * Call {@link #parseSrc()} before calling this method. If you call this method,
+     * do not call {@link #parseDest()}.
      *
-     * @param comments  any comment lines to use as the initial contents;
-     *     same format as {@link PropsFileParser.KeyPairLine#comment}. Otherwise {@code null}.
-     * @throws IllegalStateException  if {@code parseSrc()} wasn't called yet, or src was empty; {@link #size()} == 0
+     * @param comments any comment lines to use as the initial contents; same format
+     *                 as {@link PropsFileParser.KeyPairLine#comment}. Otherwise
+     *                 {@code null}.
+     * @throws IllegalStateException if {@code parseSrc()} wasn't called yet, or src
+     *                               was empty; {@link #size()} == 0
      */
     public void setDestIsNew(List<String> comments)
-        throws IllegalStateException
+            throws IllegalStateException
     {
         if (parsed.isEmpty())
             throw new IllegalStateException("call parseSrc first");
@@ -353,10 +462,12 @@ public class ParsedPropsFilePair
         if (contHeadingComment == null)
         {
             FileKeyEntry fe = new FileKeyEntry(comments);
-            fe.destComment = fe.srcComment;  // constructor sets srcComment, we need destComment instead
+            fe.destComment = fe.srcComment; // constructor sets srcComment, we need destComment instead
             fe.srcComment = null;
             contEndingComment = fe;
-        } else {
+        }
+        else
+        {
             contHeadingComment.destComment = comments;
         }
         parsed.get(0).destComment = comments;
@@ -367,20 +478,22 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Parse the destination-language file at {@link #destFile};
-     * call {@link #parseSrc()} before calling this method, so this method
-     * can merge the structures together into {@link #cont}.
-     * Do not call this method if you have called {@link #setDestIsNew(List)}.
-     *<P>
-     * Merging is done using {@link #parsed}, {@link #contHeadingComment}, and {@link #contEndingComment}.
-     * Any destination keys not found in source (in {@code #parsed}) are placed into {@link #destOnlyPairs}.
+     * Parse the destination-language file at {@link #destFile}; call
+     * {@link #parseSrc()} before calling this method, so this method can merge the
+     * structures together into {@link #cont}. Do not call this method if you have
+     * called {@link #setDestIsNew(List)}.
+     * <P>
+     * Merging is done using {@link #parsed}, {@link #contHeadingComment}, and
+     * {@link #contEndingComment}. Any destination keys not found in source (in
+     * {@code #parsed}) are placed into {@link #destOnlyPairs}.
      *
-     * @throws IllegalStateException  if {@code parseSrc()} wasn't called yet, or src was empty; {@link #size()} == 0;
-     *     or if {@link #setDestIsNew(List)} has been called
-     * @throws IOException  if file not found, cannot be read, etc
+     * @throws IllegalStateException if {@code parseSrc()} wasn't called yet, or src
+     *                               was empty; {@link #size()} == 0; or if
+     *                               {@link #setDestIsNew(List)} has been called
+     * @throws IOException           if file not found, cannot be read, etc
      */
     public void parseDest()
-        throws IllegalStateException, IOException
+            throws IllegalStateException, IOException
     {
         if (parsed.isEmpty())
             throw new IllegalStateException("call parseSrc first");
@@ -391,7 +504,7 @@ public class ParsedPropsFilePair
         final List<PropsFileParser.KeyPairLine> destLines = PropsFileParser.parseOneFile(destFile, dupeKeys);
         if (destLines.isEmpty())
             return;
-        if (! dupeKeys.isEmpty())
+        if (!dupeKeys.isEmpty())
             destParsedDupeKeys = dupeKeys;
 
         final PropsFileParser.KeyPairLine firstLine = destLines.get(0);
@@ -400,17 +513,21 @@ public class ParsedPropsFilePair
             if (contHeadingComment == null)
             {
                 FileKeyEntry fe = new FileKeyEntry(firstLine.comment);
-                fe.destComment = fe.srcComment;  // constructor sets srcComment, we need destComment instead
+                fe.destComment = fe.srcComment; // constructor sets srcComment, we need destComment instead
                 fe.srcComment = null;
                 contHeadingComment = fe;
-            } else {
+            }
+            else
+            {
                 contHeadingComment.destComment = firstLine.comment;
             }
-            destLines.remove(0);   // upcoming destLines loop expects line.key != null, except for very last entry
+            destLines.remove(0); // upcoming destLines loop expects line.key != null, except for very last entry
         }
 
-        /** Map from destination keys in destLines to {@link #cont} entries.
-         * Does not contain {@link #contHeadingComment} or {@link #contEndingComment} because their key would be null.
+        /**
+         * Map from destination keys in destLines to {@link #cont} entries. Does not
+         * contain {@link #contHeadingComment} or {@link #contEndingComment} because
+         * their key would be null.
          */
         Map<String, PropsFileParser.KeyPairLine> destKeys = new HashMap<String, PropsFileParser.KeyPairLine>();
 
@@ -421,15 +538,20 @@ public class ParsedPropsFilePair
             if (line.key != null)
             {
                 destKeys.put(line.key, line);
-            } else if (line.comment != null) {
-                // key is null, comment isn't: must be the comment(s) after the last key in the file
+            }
+            else if (line.comment != null)
+            {
+                // key is null, comment isn't: must be the comment(s) after the last key in the
+                // file
                 if (contEndingComment == null)
                 {
                     FileKeyEntry fe = new FileKeyEntry(line.comment);
-                    fe.destComment = fe.srcComment;  // constructor sets srcComment, we need destComment instead
+                    fe.destComment = fe.srcComment; // constructor sets srcComment, we need destComment instead
                     fe.srcComment = null;
                     contEndingComment = fe;
-                } else {
+                }
+                else
+                {
                     if (contEndingComment.destComment != null)
                         throw new IllegalStateException("dest: file-ending comment already exists");
                     contEndingComment.destComment = line.comment;
@@ -456,7 +578,7 @@ public class ParsedPropsFilePair
             destOnlyPairs.add(line);
 
             FileKeyEntry fe = new FileKeyEntry(line.key, line.value);
-            fe.destValue = fe.srcValue;  // constructor sets srcValue, we need destValue instead
+            fe.destValue = fe.srcValue; // constructor sets srcValue, we need destValue instead
             fe.srcValue = null;
             if (line.comment != null)
                 fe.destComment = line.comment;
@@ -470,23 +592,30 @@ public class ParsedPropsFilePair
     }
 
     /**
-     * Build {@link #cont} by combining the parsed source ({@link #parsed}) and destination ({@code destKeys}).
-     * Called from {@link #parseDest()} or {@link #setDestIsNew(List)}.
-     * Expands {@link #contHeadingComment} before iterating through keys.
-     *<P>
-     * Because {@link #parseDest()} adds entries to {@link #cont} after calling this method
-     * (for {@link #destOnlyPairs}), this method doesn't expand {@link #contEndingComment};
-     * the caller must do so by calling {@link #expandCommentLinesIntoCont(FileKeyEntry) expandCommentLinesIntoCont}
+     * Build {@link #cont} by combining the parsed source ({@link #parsed}) and
+     * destination ({@code destKeys}). Called from {@link #parseDest()} or
+     * {@link #setDestIsNew(List)}. Expands {@link #contHeadingComment} before
+     * iterating through keys.
+     * <P>
+     * Because {@link #parseDest()} adds entries to {@link #cont} after calling this
+     * method (for {@link #destOnlyPairs}), this method doesn't expand
+     * {@link #contEndingComment}; the caller must do so by calling
+     * {@link #expandCommentLinesIntoCont(FileKeyEntry) expandCommentLinesIntoCont}
      * ({@link #contEndingComment}).
      *
-     * @param destKeys  Map from destination keys in destLines to {@link #cont} entries, or {@code null}.
-     *     Does not contain {@link #contHeadingComment} or {@link #contEndingComment} because their key would be null.
-     *     <P>
-     *     <B>Note:</B> {@code destKeys} contents are modified by this method:<BR>
-     *     As entries in this map are matched to source entries with the same key, each matched entry's
-     *     {@link PropsFileParser.KeyPairLine#key KeyPairLine.key} field will be set to {@code null}.
-     *     If no source line has the same key as a given {@code destKeys} entry, at the end of the method
-     *     that entry's key field will still be {@code != null}.
+     * @param destKeys Map from destination keys in destLines to {@link #cont}
+     *                 entries, or {@code null}. Does not contain
+     *                 {@link #contHeadingComment} or {@link #contEndingComment}
+     *                 because their key would be null.
+     *                 <P>
+     *                 <B>Note:</B> {@code destKeys} contents are modified by this
+     *                 method:<BR>
+     *                 As entries in this map are matched to source entries with the
+     *                 same key, each matched entry's
+     *                 {@link PropsFileParser.KeyPairLine#key KeyPairLine.key} field
+     *                 will be set to {@code null}. If no source line has the same
+     *                 key as a given {@code destKeys} entry, at the end of the
+     *                 method that entry's key field will still be {@code != null}.
      */
     private void buildContFromSrcDest(final Map<String, PropsFileParser.KeyPairLine> destKeys)
     {
@@ -496,7 +625,7 @@ public class ParsedPropsFilePair
         for (final FileKeyEntry srcLine : parsed)
         {
             if (srcLine.key == null)
-                continue;  // ignore comments at start or end of file
+                continue; // ignore comments at start or end of file
 
             PropsFileParser.KeyPairLine dest = (destKeys != null) ? destKeys.get(srcLine.key) : null;
             if (dest != null)
@@ -510,8 +639,10 @@ public class ParsedPropsFilePair
                     expandCommentLinesIntoCont(srcLine);
                 cont.add(srcLine);
 
-                dest.key = null;  // mark as matched to src, not left over for destOnlyPairs in parseDest()
-            } else {
+                dest.key = null; // mark as matched to src, not left over for destOnlyPairs in parseDest()
+            }
+            else
+            {
                 // this key is in source only
                 if (srcLine.srcComment != null)
                     expandCommentLinesIntoCont(srcLine);
@@ -520,63 +651,71 @@ public class ParsedPropsFilePair
         }
     }
 
-    /** Expand this key-value entry's preceding comment(s) to new lines appended at the end of {@link #cont}. */
+    /**
+     * Expand this key-value entry's preceding comment(s) to new lines appended at
+     * the end of {@link #cont}.
+     */
     private final void expandCommentLinesIntoCont(final FileKeyEntry fe)
     {
-        // TODO line up comments on lines above src, dest: bottom-justify, not top-justify, if not the same number of comment lines
-        final int nSrc  = (fe.srcComment != null)  ? fe.srcComment.size()  : 0,
-                  nDest = (fe.destComment != null) ? fe.destComment.size() : 0,
-                  nComment = (nSrc >= nDest) ? nSrc : nDest;
+        // TODO line up comments on lines above src, dest: bottom-justify, not
+        // top-justify, if not the same number of comment lines
+        final int nSrc = (fe.srcComment != null) ? fe.srcComment.size() : 0,
+                nDest = (fe.destComment != null) ? fe.destComment.size() : 0,
+                nComment = (nSrc >= nDest) ? nSrc : nDest;
         for (int i = 0; i < nComment; ++i)
-            cont.add(new FileCommentEntry
-                    ( ((i < nSrc)  ? fe.srcComment.get(i)  : null),
-                      ((i < nDest) ? fe.destComment.get(i) : null) ));
+            cont.add(new FileCommentEntry(((i < nSrc) ? fe.srcComment.get(i) : null),
+                    ((i < nDest) ? fe.destComment.get(i) : null)));
     }
 
     /**
-     * Add/insert a row before or after an existing row.
-     * Added rows are {@link FileKeyEntry} until {@link #convertInsertedRows()} is called,
-     * they may become {@link FileCommentEntry} at that time.
+     * Add/insert a row before or after an existing row. Added rows are
+     * {@link FileKeyEntry} until {@link #convertInsertedRows()} is called, they may
+     * become {@link FileCommentEntry} at that time.
      *
-     * @param r  Row number
-     * @param beforeRow  If true, insert before (above), otherwise add after (below) this line; ignored if
-     *     adding at end ({@code r} == {@link #size()})
-     * @throws IndexOutOfBoundsException  if {@code r} is &lt; 0 or &gt; {@link #size()}
+     * @param r         Row number
+     * @param beforeRow If true, insert before (above), otherwise add after (below)
+     *                  this line; ignored if adding at end ({@code r} ==
+     *                  {@link #size()})
+     * @throws IndexOutOfBoundsException if {@code r} is &lt; 0 or &gt;
+     *                                   {@link #size()}
      */
     public void insertRow(int r, final boolean beforeRow)
-        throws IndexOutOfBoundsException
+            throws IndexOutOfBoundsException
     {
-        if (! beforeRow)
+        if (!beforeRow)
             ++r;
 
         FileKeyEntry fke = new FileKeyEntry(null, null);
         fke.newAdd = true;
         if (r < cont.size())
-            cont.add(r, fke);  // throws IndexOutOfBoundsException if out of range
+            cont.add(r, fke); // throws IndexOutOfBoundsException if out of range
         else
             cont.add(fke);
 
-        if (! unsavedInsRows)
+        if (!unsavedInsRows)
             unsavedInsRows = true;
     }
 
     /**
-     * Check for rows added by the editor, with the {@link FileKeyEntry#newAdd} flag;
-     * inspect these for keys and values, and if needed convert them to {@link FileCommentEntry}.
-     * @return  True if any rows had the flag and had their contents converted (keys, values, or comments)
+     * Check for rows added by the editor, with the {@link FileKeyEntry#newAdd}
+     * flag; inspect these for keys and values, and if needed convert them to
+     * {@link FileCommentEntry}.
+     * 
+     * @return True if any rows had the flag and had their contents converted (keys,
+     *         values, or comments)
      */
     public boolean convertInsertedRows()
     {
         boolean foundAny = false;
 
-        for (ListIterator<FileEntry> li = cont.listIterator(); li.hasNext(); )
+        for (ListIterator<FileEntry> li = cont.listIterator(); li.hasNext();)
         {
             FileEntry fe = li.next();
-            if (! (fe instanceof FileKeyEntry))
+            if (!(fe instanceof FileKeyEntry))
                 continue;
 
             FileKeyEntry fke = (FileKeyEntry) fe;
-            if (! fke.newAdd)
+            if (!fke.newAdd)
                 continue;
 
             if ((fke.key == null) || (fke.key.length() == 0))
@@ -584,11 +723,11 @@ public class ParsedPropsFilePair
                 // No key: this is a comment or blank line
                 foundAny = true;
 
-                String srcComm  = (fke.srcValue != null)  ? fke.srcValue.toString().trim()  : null,
-                       destComm = (fke.destValue != null) ? fke.destValue.toString().trim() : null;
-                if ((srcComm != null) && ! srcComm.startsWith("#"))
+                String srcComm = (fke.srcValue != null) ? fke.srcValue.toString().trim() : null,
+                        destComm = (fke.destValue != null) ? fke.destValue.toString().trim() : null;
+                if ((srcComm != null) && !srcComm.startsWith("#"))
                     srcComm = "# " + srcComm;
-                if ((destComm != null) && ! destComm.startsWith("#"))
+                if ((destComm != null) && !destComm.startsWith("#"))
                     destComm = "# " + destComm;
 
                 FileCommentEntry fce = new FileCommentEntry(srcComm, destComm);
@@ -605,16 +744,23 @@ public class ParsedPropsFilePair
     //
 
     /**
-     * One message key or comment line, with its source and destination languages' string values and comments.
+     * One message key or comment line, with its source and destination languages'
+     * string values and comments.
+     * 
      * @see FileKeyEntry
      * @see FileCommentEntry
      */
-    public static abstract class FileEntry {}
+    public static abstract class FileEntry
+    {
+    }
 
     /** Comment line in source and destination */
     public static final class FileCommentEntry extends FileEntry
     {
-        /** Comment field strings start with {@code #} and are trimmed; may be null or "" on blank lines. */
+        /**
+         * Comment field strings start with {@code #} and are trimmed; may be null or ""
+         * on blank lines.
+         */
         public String srcComment, destComment;
 
         public FileCommentEntry(final String srcComment)
@@ -628,21 +774,26 @@ public class ParsedPropsFilePair
             this.destComment = destComment;
         }
 
-        public final String toString() { return "FileCommentEntry"; }
+        public final String toString()
+        {
+            return "FileCommentEntry";
+        }
     }
 
     /**
-     * Key-value pair line in source and destination, with preceding comments, or multi-line
-     * comment at the end of the file.
-     *<P>
-     * Also used by editor for newly inserted lines, when we are unsure if they will be comments or key-value.
-     * To convert those before saving, call {@link ParsedPropsFilePair#convertInsertedRows()}.
+     * Key-value pair line in source and destination, with preceding comments, or
+     * multi-line comment at the end of the file.
+     * <P>
+     * Also used by editor for newly inserted lines, when we are unsure if they will
+     * be comments or key-value. To convert those before saving, call
+     * {@link ParsedPropsFilePair#convertInsertedRows()}.
      */
     public static final class FileKeyEntry extends FileEntry
     {
         /**
-         * Is this line newly added in the editor during this edit session?
-         * Remains true even after saving the file, so its {@link #key} can still be edited.
+         * Is this line newly added in the editor during this edit session? Remains true
+         * even after saving the file, so its {@link #key} can still be edited.
+         * 
          * @see ParsedPropsFilePair#convertInsertedRows()
          */
         public boolean newAdd;
@@ -650,52 +801,64 @@ public class ParsedPropsFilePair
         /** key for retrieval, or {@code null} for comments at the end of the file */
         public String key;
 
-        /** Preceding comment lines and/or blank lines in the source language, or {@code null};
-         *  same format as {@link PropsFileParser.KeyPairLine#comment}
+        /**
+         * Preceding comment lines and/or blank lines in the source language, or
+         * {@code null}; same format as {@link PropsFileParser.KeyPairLine#comment}
          */
         public List<String> srcComment;
 
-        /** Preceding comment lines and/or blank lines in the destination language, or {@code null};
-         *  same format as {@link PropsFileParser.KeyPairLine#comment}
+        /**
+         * Preceding comment lines and/or blank lines in the destination language, or
+         * {@code null}; same format as {@link PropsFileParser.KeyPairLine#comment}
          */
         public List<String> destComment;
 
-        /** Value in source language, or {@code null} for a key defined only in the destination file, or for
-         *  empty strings or only whitespace.
+        /**
+         * Value in source language, or {@code null} for a key defined only in the
+         * destination file, or for empty strings or only whitespace.
          */
         public CharSequence srcValue;
 
-        /** Value in destination language, or {@code null}. Empty strings or only whitespace are {@code null}. */
+        /**
+         * Value in destination language, or {@code null}. Empty strings or only
+         * whitespace are {@code null}.
+         */
         public CharSequence destValue;
 
-        /** If true, the key and value are separated by " = " instead of "=".
-         *  This is tracked to minimize whitespace changes when editing a properties file.
-         *  True by default except comment lines; set false after constructor if needed.
+        /**
+         * If true, the key and value are separated by " = " instead of "=". This is
+         * tracked to minimize whitespace changes when editing a properties file. True
+         * by default except comment lines; set false after constructor if needed.
          */
         public boolean srcSpacedEquals, destSpacedEquals;
 
         /**
          * Create an entry for a source language (no destination value yet).
+         * 
          * @param key
          * @param srcValue
          * @throws IllegalArgumentException if {@code key} is null
          */
         public FileKeyEntry(final String key, final String srcValue)
-            throws IllegalArgumentException
+                throws IllegalArgumentException
         {
             this(key, srcValue, null);
         }
 
         /**
          * Create an entry for a source and destination.
-         * @param key  Key for retrieval.  May be {@code null} only if inserting a new line which may become a comment.
-         *                Before saving, set the key and value, or convert to {@link FileCommentEntry}.
-         * @param srcValue  Value in source language, or {@code null} for empty or only whitespace
-         * @param destValue  Value in destination language, or {@code null} for undefined, empty or only whitespace
+         * 
+         * @param key       Key for retrieval. May be {@code null} only if inserting a
+         *                  new line which may become a comment. Before saving, set the
+         *                  key and value, or convert to {@link FileCommentEntry}.
+         * @param srcValue  Value in source language, or {@code null} for empty or only
+         *                  whitespace
+         * @param destValue Value in destination language, or {@code null} for
+         *                  undefined, empty or only whitespace
          * @throws IllegalArgumentException if {@code key} is null
          */
         public FileKeyEntry(final String key, final String srcValue, final String destValue)
-            throws IllegalArgumentException
+                throws IllegalArgumentException
         {
             this.key = key;
             this.srcValue = srcValue;
@@ -705,8 +868,10 @@ public class ParsedPropsFilePair
         }
 
         /**
-         * Create an entry that's only a comment without a following key-value pair (at the end of the file).
-         * @param srcComment  Comment text in the source language file
+         * Create an entry that's only a comment without a following key-value pair (at
+         * the end of the file).
+         * 
+         * @param srcComment Comment text in the source language file
          */
         public FileKeyEntry(final List<String> srcComment)
         {
@@ -714,7 +879,10 @@ public class ParsedPropsFilePair
             this.srcComment = (srcComment.isEmpty()) ? null : srcComment;
         }
 
-        /** toString includes the source and destination values, and number of source and destination comment lines. */
+        /**
+         * toString includes the source and destination values, and number of source and
+         * destination comment lines.
+         */
         public final String toString()
         {
             return "{key=" + key


### PR DESCRIPTION
**Summary of the refactor:** Eliminates conditional branching based on a flag which makes the extraction logic easier to maintain and extend via the Strategy pattern.
**Mention of the design pattern used:** Strategy
**Verification notes (tests run, manual steps):** All existing tests pass and are relevant.
<img width="563" height="180" alt="image" src="https://github.com/user-attachments/assets/59fdbcd2-325e-4330-ab02-7dd5641af44f" />

closes #70 