### PR TITLE
630:P3 GameAction Telescoping constructor → Builder pattern

### DIFF
--- a/src/main/java/soc/game/GameAction.java
+++ b/src/main/java/soc/game/GameAction.java
@@ -218,6 +218,112 @@ public class GameAction
     }
 
     /**
+     * Builder for GameAction constructor; does not yet
+     * replace the current constructors
+     * 
+     * @param aType GameAction type of the action; should not be null
+     */
+    public static Builder builder(final ActionType aType)
+    {
+        return new Builder(aType);
+    }
+
+    public static class Builder
+    {
+        private final ActionType actType;
+
+        private int param1;
+        private int param2;
+        private int param3;
+
+        private ResourceSet rset1;
+        private ResourceSet rset2;
+
+        private List<Effect> effects;
+
+        private Builder(final ActionType aType)
+        {
+            if (aType == null)
+                throw new IllegalArgumentException("aType");
+
+            actType = aType;
+        }
+
+        public Builder params(final int p1, final int p2, final int p3)
+        {
+            param1 = p1;
+            param2 = p2;
+            param3 = p3;
+            return this;
+        }
+
+        public Builder param1(final int p1)
+        {
+            param1 = p1;
+            return this;
+        }
+
+        public Builder param2(final int p2)
+        {
+            param2 = p2;
+            return this;
+        }
+
+        public Builder param3(final int p3)
+        {
+            param3 = p3;
+            return this;
+        }
+
+        public Builder resourceSets(final ResourceSet rs1, final ResourceSet rs2)
+        {
+            rset1 = rs1;
+            rset2 = rs2;
+            return this;
+        }
+
+        public Builder resourceSet1(final ResourceSet rs1)
+        {
+            rset1 = rs1;
+            return this;
+        }
+
+        public Builder resourceSet2(final ResourceSet rs2)
+        {
+            rset2 = rs2;
+            return this;
+        }
+
+        public Builder effects(final List<Effect> effects)
+        {
+            this.effects = effects;
+            return this;
+        }
+
+        public GameAction build()
+        {
+            return new GameAction(actType, param1, param2, param3, rset1, rset2, effects);
+        }
+    }
+
+    /**
+     * Builder-based version of {@link #GameAction(final GameAction copyFrom, ActionType aType, final int p1, final int p2, final int p3)},
+     * which makes a copy of a GameAction, as mentioned in its comments
+     * @param copyFrom
+     * @return
+     */
+    public static Builder copyOf(final GameAction copyFrom, final ActionType aType)
+    {
+        if (copyFrom == null)
+            throw new NullPointerException("copyFrom");
+
+        return new Builder(aType)
+            .params(copyFrom.param1, copyFrom.param2, copyFrom.param3)
+            .resourceSets(copyFrom.rset1, copyFrom.rset2)
+            .effects(copyFrom.effects);
+    }
+
+    /**
      * Contents for debugging, formatted like:
      *<pre>
      * GameAction(ROLL_DICE, p1=12)

--- a/src/main/java/soc/game/SOCGame.java
+++ b/src/main/java/soc/game/SOCGame.java
@@ -4943,8 +4943,7 @@ public class SOCGame implements Serializable, Cloneable
         if ((lastAction != null) && (lastAction.actType == ActionType.BUILD_PIECE))
         {
             // change lastAction from BUILD_PIECE to MOVE_PIECE, but keep anything like revealed fog hex info
-            final GameAction moveAction = new GameAction
-                (lastAction, ActionType.MOVE_PIECE, sh.getType(), fromEdge, toEdge);
+            final GameAction moveAction = GameAction.copyOf(lastAction, ActionType.MOVE_PIECE).params(sh.getType(), fromEdge, toEdge).build();
             moveAction.cannotUndoReason = lastAction.cannotUndoReason;
             lastAction = moveAction;
         }
@@ -8447,7 +8446,7 @@ public class SOCGame implements Serializable, Cloneable
             // trade is undo
             lastAction = null;
         } else {
-            lastAction = new GameAction(ActionType.TRADE_BANK, give, get);
+            lastAction = GameAction.builder(ActionType.TRADE_BANK).resourceSets(give, get).build();
         }
 
         currPlayer.makeBankTrade(give, get);


### PR DESCRIPTION
Closes #85 
___

**Summary:**

Adds a builder class to GameAction, meant to eventually replace the telescoping constructor currently in use. The builder should hopefully make call sites clearer. Since there are a huge number of `new GameAction` calls, this PR does not remove the old constructors entirely.  Changes two call sites in `SOCGame` were made to test that builder functioned without issue.

**Pattern Used:**

Builder

**Verification:**

All existing tests passed locally. Started a game via the GUI without issue.

<img width="997" height="344" alt="image" src="https://github.com/user-attachments/assets/cb255396-e9ac-464e-b11b-ff30a609ea42" />